### PR TITLE
Added safe stringifying for circular JSON

### DIFF
--- a/lib/event-source.js
+++ b/lib/event-source.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var stringify = require('json-stringify-safe');
+
 function EventSource() {
     this._connections = [];
 }
@@ -14,7 +16,7 @@ EventSource.prototype = {
     emit: function(event, data) {
         this._connections.forEach(function(connection) {
             connection.write('event: ' + event + '\n');
-            connection.write('data: ' + JSON.stringify(data) + '\n');
+            connection.write('data: ' + stringify(data) + '\n');
             connection.write('\n\n');
         });
     }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express": "^4.8.6",
     "express-handlebars": "^1.0.3",
     "handlebars": "^1.3.0",
+    "json-stringify-safe": "^5.0.1",
     "opener": "^1.4.0",
     "q": "^1.0.1",
     "q-io": "^1.11.4",

--- a/test/event-source.test.js
+++ b/test/event-source.test.js
@@ -21,4 +21,15 @@ describe('EventSource', function() {
         expect(this.connection.write.secondCall.args[0]).to.equal('data: {"data":"value"}\n');
         expect(this.connection.write.thirdCall.args[0]).to.equal('\n\n');
     });
+
+    it('should handle circular references format', function() {
+        var a = {b: true};
+        a.c = a;
+        this.source.emit('event', a);
+
+        expect(this.connection.write.callCount).to.equal(3);
+        expect(this.connection.write.firstCall.args[0]).to.equal('event: event\n');
+        expect(this.connection.write.secondCall.args[0]).to.equal('data: {"b":true,"c":"[Circular ~]"}\n');
+        expect(this.connection.write.thirdCall.args[0]).to.equal('\n\n');
+    });
 });


### PR DESCRIPTION
When passing a callback to `suite.capture`, the data being sent becomes circular (i.e. there is a reference to itself within the JSON).

```js
// Works
suite.capture('plain');

// Errors out
suite.capture('plain', function (actions) {
  action.setWindowSize(1024, 768);
});  
```

Unfortunately, this was a hard bug to track down as `gemini-gui` would silently exit rather than give me a stack trace =/

After adding a `console.log` to here, I found the error and patched it with `json-stringify-safe`:

https://github.com/gemini-testing/gemini/blob/6499b54110bc197f3262d26e9be0c90fec6dc94e/lib/runner.js#L72-L75

In this PR:

- Added fix for circular JSON by using `json-stringify-safe`
- Added regression test to prevent the issue from recurring