### PR TITLE
Added retry button to retry all states. Added buttons to retry failed states.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,7 +19,9 @@
     "maxparams": 3,
     "node": true,
     "overrides": {
-      "test/*": {"mocha": true},
+      "test/**": {
+        "mocha": true
+      },
       "lib/client/*": {
         "node": false,
         "browserify": true,
@@ -28,5 +30,9 @@
           "EventSource": false
         }
       }
+    },
+    "globals": {
+      "expect": false,
+      "sinon": false
     }
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -6,11 +6,12 @@ var path = require('path'),
     temp = require('temp'),
     _ = require('lodash'),
     findGemini = require('./find-gemini'),
+    reporter = require('./reporter'),
 
     Tests = require('./tests-model'),
     Index = require('./common/tests-index'),
     EventSource = require('./event-source'),
-    reporter = require('./reporter');
+    Runner = require('./runner');
 
 function removeTreeIfExists(path) {
     return fs.exists(path)
@@ -22,12 +23,15 @@ function removeTreeIfExists(path) {
 }
 
 function App(options) {
+    this._options = options;
     this.diffDir = temp.path('gemini-gui-diff');
     this.currentDir = temp.path('gemini-gui-curr');
+    this._failedTests = new Index();
+
     this._eventSource = new EventSource();
 
     var Gemini = findGemini();
-    this._gemini = new Gemini(options.configFile, {cli: true, env: true});
+    this._gemini = new Gemini(this._options.configFile, {cli: true, env: true});
 
     var browserIds = this._gemini.browserIds;
     this.referenceDirs = _.zipObject(
@@ -38,6 +42,11 @@ function App(options) {
     );
 }
 
+App.prototype.initialize = function() {
+    return this._recreateTmpDirs()
+        .then(this._readTests.bind(this));
+};
+
 App.prototype.addClient = function(connection) {
     this._eventSource.addConnection(connection);
 };
@@ -46,27 +55,27 @@ App.prototype.sendClientEvent = function(event, data) {
     this._eventSource.emit(event, data);
 };
 
-App.prototype.readTests = function(paths, grep) {
-    var _this = this;
-    if (!this._tests) {
-        return this._gemini.readTests(paths, grep)
-            .then(function(suiteCollection) {
-                _this._tests = new Tests(_this, suiteCollection);
-                return _this._tests.data;
-            });
-    }
+App.prototype.getTests = function() {
     return q.resolve(this._tests.data);
 };
 
-App.prototype.run = function(paths, grep) {
+App.prototype._readTests = function() {
     var _this = this;
-    this._failedTests = new Index();
-    return this._recreateTmpDirs()
-        .then(function() {
-            return _this._gemini.test(paths, {
+
+    return this._gemini.readTests(this._options.testFiles, this._options.grep)
+        .then(function(collection) {
+            _this._collection = collection;
+            _this._tests = new Tests(_this, collection);
+        });
+};
+
+App.prototype.run = function(specificTests) {
+    var _this = this;
+    return Runner.create(this._collection, specificTests)
+        .run(function(collection) {
+            return _this._gemini.test(collection, {
                 reporters: [reporter(_this), 'flat'],
-                tempDir: _this.currentDir,
-                grep: grep
+                tempDir: _this.currentDir
             });
         });
 };
@@ -116,8 +125,7 @@ App.prototype.updateReferenceImage = function(testData) {
     return fs.copy(test.currentPath, test.referencePath)
         .then(function() {
             console.log('Reference image %s has been updated.', test.referencePath);
-            // add query string timestamp to avoid caching on client
-            return _this.refPathToURL(test.referencePath, test.browserId) + '?t=' + new Date().valueOf();
+            return _this.refPathToURL(test.referencePath, test.browserId);
         });
 };
 
@@ -130,11 +138,20 @@ App.prototype.getBrowserCapabilites = function(browserId) {
 };
 
 App.prototype.refPathToURL = function(fullPath, browserId) {
-    return this._pathToURL(this.referenceDirs[browserId], fullPath, App.refPrefix + '/' + browserId);
+    return this._appendTimestampToURL(
+        this._pathToURL(this.referenceDirs[browserId], fullPath, App.refPrefix + '/' + browserId)
+    );
 };
 
 App.prototype.currentPathToURL = function(fullPath) {
-    return this._pathToURL(this.currentDir, fullPath, App.currentPrefix);
+    return this._appendTimestampToURL(
+        this._pathToURL(this.currentDir, fullPath, App.currentPrefix)
+    );
+};
+
+// add query string timestamp to avoid caching on client
+App.prototype._appendTimestampToURL = function(URL) {
+    return URL + '?t=' + new Date().valueOf();
 };
 
 App.prototype.diffPathToURL = function(fullPath) {

--- a/lib/client/controller.js
+++ b/lib/client/controller.js
@@ -1,0 +1,174 @@
+/*jshint browser:true*/
+'use strict';
+
+var SectionList = require('./section-list'),
+    xhr = require('./xhr'),
+    byId = document.getElementById.bind(document),
+    byClass = document.getElementsByClassName.bind(document);
+
+function Controller() {
+    this._sections = new SectionList(this);
+    this._runButton = byId('run');
+    this._runFailedButton = byId('runFailed');
+
+    this._handleButtonClicks();
+    this._listenForEvents();
+}
+
+Controller.prototype = {
+    runState: function(state) {
+        this._run(state);
+    },
+
+    _runAllFailed: function() {
+        var failed = this._sections.findFailedStates();
+
+        if (failed.length) {
+            this._run(this._sections.findFailedStates());
+        }
+    },
+
+    _run: function(failed) {
+        var _this = this;
+
+        this._toggleButtons(false);
+
+        xhr.post('/run', failed, function(error) {
+            if (error) {
+                return;
+            }
+            return failed? _this._sections.markAsQueued(failed) : _this._sections.markAllAsQueued();
+        });
+    },
+
+    _toggleButtons: function(isEnabled) {
+        Array.prototype.forEach.call(byClass('button_togglable'), function(element) {
+            element.disabled = !isEnabled;
+        });
+    },
+
+    _handleButtonClicks: function() {
+        var sections = this._sections,
+            _this = this;
+
+        byId('expandAll').addEventListener('click', sections.expandAll.bind(sections));
+        byId('collapseAll').addEventListener('click', sections.collapseAll.bind(sections));
+        byId('expandErrors').addEventListener('click', sections.expandErrors.bind(sections));
+
+        this._runButton.addEventListener('click', function() {
+            _this._run();
+        });
+        this._runFailedButton.addEventListener('click', this._runAllFailed.bind(this));
+    },
+
+    _listenForEvents: function() {
+        var eventSource = new EventSource('/events'),
+            _this = this;
+
+        eventSource.addEventListener('beginSuite', function(e) {
+            var data = JSON.parse(e.data),
+                section = _this._sections.findSection({suite: data.suite});
+
+            if (section && section.status === 'queued') {
+                section.status = 'running';
+            }
+        });
+
+        eventSource.addEventListener('beginState', function(e) {
+            var data = JSON.parse(e.data),
+                section = _this._sections.findSection({
+                    suite: data.suite,
+                    state: data.state
+                });
+
+            if (section && section.status === 'queued') {
+                section.status = 'running';
+            }
+        });
+
+        eventSource.addEventListener('endTest', function(e) {
+            var data = JSON.parse(e.data),
+                section = _this._sections.findSection({
+                    suite: data.suite,
+                    state: data.state,
+                    browserId: data.browserId
+                });
+
+            if (data.equal) {
+                section.setAsSuccess(data);
+            } else {
+                section.setAsFailure(data);
+                section.expand();
+                _this._sections.markBranchAsFailed(section);
+            }
+        });
+
+        eventSource.addEventListener('skipState', function(e) {
+            var data = JSON.parse(e.data),
+                section = _this._sections.findSection({
+                    suite: data.suite,
+                    state: data.state,
+                    browserId: data.browserId
+                });
+            section.setAsSkipped();
+            var stateSection = _this._sections.findSection({
+                suite: data.suite,
+                state: data.state
+            });
+
+            _this._sections.markIfFinished(stateSection);
+        });
+
+        eventSource.addEventListener('err', function(e) {
+            var data = JSON.parse(e.data),
+                section = _this._sections.findSection({
+                    suite: data.suite,
+                    state: data.state,
+                    browserId: data.browserId
+                });
+            section.setAsError({stack: data.stack});
+            section.expand();
+            _this._sections.markBranchAsFailed(section);
+        });
+
+        eventSource.addEventListener('noReference', function(e) {
+            var data = JSON.parse(e.data),
+                section = _this._sections.findSection({
+                    suite: data.suite,
+                    state: data.state,
+                    browserId: data.browserId
+                });
+
+            section.setAsNewReference(data);
+            section.expand();
+            _this._sections.markBranchAsFailed(section);
+        });
+
+        eventSource.addEventListener('endState', function(e) {
+            var data = JSON.parse(e.data),
+                section = _this._sections.findSection({
+                    suite: data.suite,
+                    state: data.state
+                });
+
+            _this._sections.markIfFinished(section);
+        });
+
+        eventSource.addEventListener('endSuite', function(e) {
+            var data = JSON.parse(e.data),
+                section = _this._sections.findSection({
+                    suite: data.suite,
+                    state: data.state,
+                    browserId: data.browserId
+                });
+
+            _this._sections.markIfFinished(section);
+        });
+
+        eventSource.addEventListener('end', function(e) {
+            _this._toggleButtons(true);
+        });
+    }
+};
+
+module.exports = Controller;

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,138 +1,22 @@
 /*jshint browser:true*/
 'use strict';
-var SectionList = require('./section-list'),
-    xhr = require('./xhr'),
-    byId = document.getElementById.bind(document),
-    runButton,
-    sections,
+var Controller = require('./controller'),
     forEach = Array.prototype.forEach,
     filter = Array.prototype.filter,
     hbruntime = require('hbsfy/runtime');
 
 hbruntime.registerPartial('cswitcher', require('../views/partials/cswitcher.hbs'));
 
-function failAllParents(section) {
-    while ((section = sections.findParent(section))) {
-        section.status = 'fail';
-        section.expand();
+function bodyClick(e) {
+    var target = e.target;
+    if (target.classList.contains('cswitcher__item')) {
+        handleColorSwitch(
+            target,
+            filter.call(target.parentNode.childNodes, function(node) {
+                return node.nodeType === Node.ELEMENT_NODE;
+            })
+        );
     }
-}
-
-function listenForEvents() {
-    var eventSource = new EventSource('/events');
-
-    eventSource.addEventListener('beginSuite', function(e) {
-        var data = JSON.parse(e.data),
-            section = sections.findSection({suite: data.suite});
-
-        if (section && section.status === 'queued') {
-            section.status = 'running';
-        }
-    });
-
-    eventSource.addEventListener('beginState', function(e) {
-        var data = JSON.parse(e.data),
-            section = sections.findSection({
-                suite: data.suite,
-                state: data.state
-            });
-
-        if (section && section.status === 'queued') {
-            section.status = 'running';
-        }
-    });
-
-    eventSource.addEventListener('endTest', function(e) {
-        var data = JSON.parse(e.data),
-            section = sections.findSection({
-                suite: data.suite,
-                state: data.state,
-                browserId: data.browserId
-            });
-
-        if (data.equal) {
-            section.setAsSuccess(data);
-        } else {
-            section.setAsFailure(data);
-            section.expand();
-            failAllParents(section);
-        }
-    });
-
-    eventSource.addEventListener('skipState', function(e) {
-        var data = JSON.parse(e.data),
-            section = sections.findSection({
-                suite: data.suite,
-                state: data.state,
-                browserId: data.browserId
-            });
-        section.setAsSkipped();
-        var stateSection = sections.findSection({
-            suite: data.suite,
-            state: data.state
-        });
-
-        sections.markIfFinished(stateSection);
-    });
-
-    eventSource.addEventListener('err', function(e) {
-        var data = JSON.parse(e.data),
-            section = sections.findSection({
-                suite: data.suite,
-                state: data.state,
-                browserId: data.browserId
-            });
-        section.setAsError({stack: data.stack});
-        section.expand();
-        failAllParents(section);
-    });
-
-    eventSource.addEventListener('noReference', function(e) {
-        var data = JSON.parse(e.data),
-            section = sections.findSection({
-                suite: data.suite,
-                state: data.state,
-                browserId: data.browserId
-            });
-
-        section.setAsNewReference(data);
-        section.expand();
-        failAllParents(section);
-    });
-
-    eventSource.addEventListener('endState', function(e) {
-        var data = JSON.parse(e.data),
-            section = sections.findSection({
-                suite: data.suite,
-                state: data.state
-            });
-
-        sections.markIfFinished(section);
-    });
-
-    eventSource.addEventListener('endSuite', function(e) {
-        var data = JSON.parse(e.data),
-            section = sections.findSection({
-                suite: data.suite,
-                state: data.state,
-                browserId: data.browserId
-            });
-
-        sections.markIfFinished(section);
-    });
-
-    eventSource.addEventListener('end', function(e) {
-        runButton.disabled = false;
-    });
-}
-
-function run() {
-    runButton.disabled = true;
-    xhr.post('/run', function(error, data) {
-        if (!error) {
-            sections.markAllAsQueued();
-        }
-    });
 }
 
 function handleColorSwitch(target, sources) {
@@ -151,18 +35,6 @@ function handleColorSwitch(target, sources) {
     imageBox.classList.add('cswitcher_color_' + target.dataset.id);
 }
 
-function bodyClick(e) {
-    var target = e.target;
-    if (target.classList.contains('cswitcher__item')) {
-        handleColorSwitch(
-            target,
-            filter.call(target.parentNode.childNodes, function(node) {
-                return node.nodeType === Node.ELEMENT_NODE;
-            })
-        );
-    }
-}
-
 function findClosest(context, cls) {
     while ((context = context.parentNode)) {
         if (context.classList.contains(cls)) {
@@ -172,13 +44,6 @@ function findClosest(context, cls) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-    sections = new SectionList();
-    runButton = byId('run');
-    listenForEvents();
-
-    byId('expandAll').addEventListener('click', sections.expandAll.bind(sections));
-    byId('collapseAll').addEventListener('click', sections.collapseAll.bind(sections));
-    byId('expandErrors').addEventListener('click', sections.expandErrors.bind(sections));
-    runButton.addEventListener('click', run);
+    document.controller = new Controller();
     document.body.addEventListener('click', bodyClick);
 });

--- a/lib/client/section-list.js
+++ b/lib/client/section-list.js
@@ -5,11 +5,12 @@ var Section = require('./section'),
     map = Array.prototype.map,
     every = Array.prototype.every;
 
-function SectionList() {
+function SectionList(controller) {
+    this._controller = controller;
     this._sectionsIndex = new Index();
     this._sections = map.call(document.querySelectorAll('.section'), function(node) {
         var parentNode = this._findParentSectionNode(node),
-            section = new Section(node, parentNode && this._sectionForNode(parentNode));
+            section = new Section(node, parentNode && this._sectionForNode(parentNode), this._onRunState.bind(this));
 
         this._sectionsIndex.add(section);
         return section;
@@ -37,6 +38,21 @@ SectionList.prototype = {
         });
     },
 
+    markAsQueued: function(leafQueries) {
+        leafQueries = [].concat(leafQueries);
+
+        var _this = this;
+
+        this._sectionsIndex.find(leafQueries)
+            .forEach(function(section) {
+                section.setAsQueued();
+
+                while ((section = _this.findParent(section))) {
+                    section.status = 'queued';
+                }
+            });
+    },
+
     markAllAsQueued: function() {
         this._sections.forEach(function(section) {
             section.status = 'queued';
@@ -55,6 +71,13 @@ SectionList.prototype = {
 
         if (allChildrenFinished) {
             section.status = 'success';
+        }
+    },
+
+    markBranchAsFailed: function(fromSection) {
+        while ((fromSection = this.findParent(fromSection))) {
+            fromSection.status = 'fail';
+            fromSection.expand();
         }
     },
 
@@ -80,6 +103,20 @@ SectionList.prototype = {
         return null;
     },
 
+    findFailedStates: function() {
+        return this._sections
+            .filter(function(section) {
+                return section.status === 'fail' && section.browserId;
+            })
+            .map(function(section) {
+                return {
+                    suite: section.suite,
+                    state: section.state,
+                    browserId: section.browserId
+                };
+            });
+    },
+
     _findParentSectionNode: function(node) {
         while ((node = node.parentNode)) {
             if (node.classList && node.classList.contains('section')) {
@@ -97,6 +134,10 @@ SectionList.prototype = {
         };
 
         return this.findSection(query);
+    },
+
+    _onRunState: function(state) {
+        this._controller.runState(state);
     }
 };
 

--- a/lib/client/section.js
+++ b/lib/client/section.js
@@ -30,7 +30,7 @@ function getInitialStatus(sectionNode) {
     return null;
 }
 
-function Section(node, parent) {
+function Section(node, parent, runStateHandler) {
     this.suite = {path: node.getAttribute('data-suite-path')};
     this.state = {name: node.getAttribute('data-state-name')};
     this.browserId = node.getAttribute('data-browser-id');
@@ -40,6 +40,7 @@ function Section(node, parent) {
     this._bodyNode = node.querySelector('.section__body');
     this._titleNode.addEventListener('click', this.toggle.bind(this));
     this._parent = parent;
+    this._runStateHandler = runStateHandler;
 }
 
 Section.prototype = {
@@ -77,11 +78,22 @@ Section.prototype = {
         }
     },
 
+    setAsQueued: function() {
+        this.status = 'queued';
+        while (this._bodyNode.hasChildNodes()) {
+            this._bodyNode.removeChild(this._bodyNode.firstChild);
+        }
+    },
+
     setAsFailure: function(results) {
         this.status = 'fail';
         this._bodyNode.innerHTML = failTemplate(results);
-        var replaceButton = this._bodyNode.querySelector('.image-box__replace');
+
+        var replaceButton = this._bodyNode.querySelector('.image-box__replace'),
+            retryButton = this._bodyNode.querySelector('.image-box__retry');
+
         replaceButton.addEventListener('click', this.updateReference.bind(this));
+        retryButton.addEventListener('click', this.retry.bind(this));
     },
 
     setAsSuccess: function(results) {
@@ -125,16 +137,24 @@ Section.prototype = {
 
     updateReference: function() {
         var _this = this,
-            postData = {
-                suite: this.suite,
-                state: this.state,
-                browserId: this.browserId
-            };
+            postData = this._collectStateData();
         xhr.post('/update-ref', postData, function(error, response) {
             if (!error) {
                 _this.setAsSuccess(response);
             }
         });
+    },
+
+    retry: function() {
+        this._runStateHandler(this._collectStateData());
+    },
+
+    _collectStateData: function() {
+        return {
+            suite: this.suite,
+            state: this.state,
+            browserId: this.browserId
+        };
     }
 };
 

--- a/lib/common/tests-index.js
+++ b/lib/common/tests-index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _ = require('lodash');
+
 function TestsIndex() {
     this._index = {};
 }
@@ -41,6 +43,13 @@ TestsIndex.prototype = {
     },
 
     find: function(query) {
+        if (Array.isArray(query)) {
+            return _(query)
+                .map(this.find, this)
+                .compact()
+                .value();
+        }
+
         var indexData = query.suite && this._index[query.suite.path];
         if (!indexData) {
             return null;

--- a/lib/runner/all-suites-runner.js
+++ b/lib/runner/all-suites-runner.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var inherit = require('inherit'),
+    Runner = require('./runner');
+
+var AllSuitesRunner = inherit(Runner, {
+    run: function(runHandler) {
+        this._collection.enableAll();
+
+        return this.__base(runHandler);
+    }
+});
+
+module.exports = AllSuitesRunner;

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var _ = require('lodash'),
+    AllSuitesRunner = require('./all-suites-runner'),
+    SpecificSuitesRunner = require('./specific-suites-runner');
+
+exports.create = function(collection, specificSuites) {
+    if (_.isEmpty(specificSuites)) {
+        return new AllSuitesRunner(collection);
+    }
+    return new SpecificSuitesRunner(collection, [].concat(specificSuites));
+};

--- a/lib/runner/runner.js
+++ b/lib/runner/runner.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var inherit = require('inherit');
+
+var Runner = inherit({
+    __constructor: function(collection) {
+        this._collection = collection;
+    },
+
+    run: function(runHandler) {
+        return runHandler(this._collection);
+    }
+});
+
+module.exports = Runner;

--- a/lib/runner/specific-suites-runner.js
+++ b/lib/runner/specific-suites-runner.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var inherit = require('inherit'),
+    Runner = require('./runner');
+
+var SpecificSuiteRunner = inherit(Runner, {
+    __constructor: function(collection, specificTests) {
+        this.__base(collection);
+        this._specificTests = specificTests;
+    },
+
+    run: function(runHandler) {
+        this._filter();
+
+        return this.__base(runHandler);
+    },
+
+    _filter: function() {
+        var testsToRun = this._specificTests.map(function(test) {
+            return {
+                suite: test.suite.path.replace(/,/g, ' '), //converting path to suite fullName
+                state: test.state.name,
+                browserId: test.browserId
+            };
+        });
+
+        var _this = this;
+
+        this._collection.disableAll();
+        testsToRun.forEach(function(test) {
+            _this._collection.enable(test.suite, {state: test.state, browser: test.browserId});
+        });
+    }
+});
+
+module.exports = SpecificSuiteRunner;

--- a/lib/server.js
+++ b/lib/server.js
@@ -28,7 +28,7 @@ exports.start = function(options) {
     });
 
     server.get('/', function(req, res) {
-        app.readTests(options.testFiles, options.grep)
+        app.getTests()
             .then(function(suites) {
                 res.render('main', {
                     suites: suites
@@ -46,7 +46,7 @@ exports.start = function(options) {
     });
 
     server.post('/run', function(req, res) {
-        app.run(options.testFiles, options.grep).done();
+        app.run(req.body).done();
         res.send({status: 'ok'});
     });
 
@@ -60,7 +60,10 @@ exports.start = function(options) {
             });
     });
 
-    return q.nfcall(server.listen.bind(server), options.port, options.hostname)
+    return app.initialize()
+        .then(function() {
+            return q.nfcall(server.listen.bind(server), options.port, options.hostname);
+        })
         .then(function() {
             return {
                 url: 'http://' + options.hostname + ':' + options.port

--- a/lib/views/main.hbs
+++ b/lib/views/main.hbs
@@ -4,7 +4,7 @@
         <title>Gemini</title>
         <link rel="stylesheet" type="text/css" href="main.css">
     </head>
-    
+
     <body class="report">
         {{#with stats}}
         <dl class="summary">
@@ -16,11 +16,11 @@
         {{/with}}
 
         {{#if suites.length}}
-            <button id="run" class="button button_type_action">Run</button>
+            <button id="run" class="button button_type_action button_togglable">Run</button>
             <button id="expandAll" class="button">Expand all</button>
             <button id="collapseAll" class="button">Collapse all</button>
             <button id="expandErrors" class="button">Expand errors</button>
-
+            <button id="runFailed" class="button button_togglable" disabled>Retry failed tests</button>
             {{#each suites}}
                 {{> suite}}
             {{/each}}

--- a/lib/views/partials/fail-result.hbs
+++ b/lib/views/partials/fail-result.hbs
@@ -13,4 +13,5 @@
         <div class="image-box__title">Diff</div>
         <img src="{{diffURL}}" alt="Diff image">
     </div>
+    <button class="button image-box__retry button_togglable" disabled>Retry</button>
 </div>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build-client": "browserify lib/client --debug -p [minifyify --compressPath . --map /client.js.map.json --output ./lib/static/client.js.map.json] -t hbsfy -o ./lib/static/client.js",
     "prepublish": "npm run build-client",
-    "test": "istanbul test _mocha --require ./test/index.js test",
+    "test": "istanbul test _mocha --require ./test/setup.js test/*",
     "lint": "jshint . && jscs ."
   },
   "author": "Sergey Tatarintsev <sevinf@yandex-team.ru> (https://github.com/SevInf)",
@@ -32,18 +32,20 @@
   },
   "devDependencies": {
     "browserify": "^5.11.1",
-    "chai": "^1.9.1",
-    "chai-as-promised": "^4.1.1",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^5.2.0",
+    "dirty-chai": "^1.2.2",
     "gemini": "^2.1.0",
     "hbsfy": "^2.1.0",
+    "inherit": "^2.2.3",
     "istanbul": "^0.3.2",
     "jscs": "^1.6.2",
     "jshint": "^2.5.6",
     "minifyify": "^4.2.0",
-    "mocha": "^1.21.4",
+    "mocha": "^2.4.4",
     "proxyquire": "^1.7.3",
-    "sinon": "^1.10.3",
-    "sinon-chai": "^2.5.0",
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0",
     "watchify": "^1.0.2"
   },
   "directories": {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,28 +1,128 @@
 'use strict';
 
-var sinon = require('sinon'),
-    expect = require('chai').expect,
-    proxyquire = require('proxyquire'),
-    App;
+var proxyquire = require('proxyquire'),
+    q = require('q'),
+    fs = require('q-io/fs'),
+    RunnerFactory = require('../lib/runner'),
+    AllSuitesRunner = require('../lib/runner/all-suites-runner'),
+    App,
+
+    mkDummyCollection = require('./utils').mkDummyCollection;
 
 describe('App', function() {
     var sandbox = sinon.sandbox.create(),
+        suiteCollection,
         Gemini,
         app;
 
+    function stubFs_() {
+        sandbox.stub(fs, 'exists').returns(q(false));
+        sandbox.stub(fs, 'removeTree').returns(q());
+        sandbox.stub(fs, 'makeDirectory').returns(q());
+    }
+
+    function mkApp_(config) {
+        return new App(config || {});
+    }
+
     beforeEach(function() {
+        suiteCollection = mkDummyCollection();
+
         Gemini = sandbox.stub();
         Gemini.prototype.browserIds = [];
+        Gemini.prototype.readTests = sandbox.stub().returns(q(suiteCollection));
+        Gemini.prototype.test = sandbox.stub().returns(q());
 
         App = proxyquire('../lib/app', {
             './find-gemini': sandbox.stub().returns(Gemini)
         });
 
-        app = new App({});
+        app = mkApp_();
     });
 
     afterEach(function() {
         sandbox.restore();
+    });
+
+    describe('initialize', function() {
+        beforeEach(function() {
+            stubFs_();
+        });
+
+        it('should remove old fs tree for current images dir if it exists', function() {
+            app.currentDir = 'current_dir';
+
+            fs.exists.withArgs('current_dir').returns(q(true));
+
+            return app.initialize()
+                .then(function() {
+                    expect(fs.removeTree).to.be.calledWith('current_dir');
+                });
+        });
+
+        it('should remove old fs tree for diff images dir if it exists', function() {
+            app.diffDir = 'diff_dir';
+
+            fs.exists.withArgs('diff_dir').returns(q(true));
+
+            return app.initialize()
+                .then(function() {
+                    expect(fs.removeTree).to.be.calledWith('diff_dir');
+                });
+        });
+
+        it('should create new tree for current images dir', function() {
+            app.currentDir = 'current_dir';
+
+            return app.initialize()
+                .then(function() {
+                    expect(fs.makeDirectory).to.be.calledWith('current_dir');
+                });
+        });
+
+        it('should create new tree for diff images dir', function() {
+            app.currentDir = 'diff_dir';
+
+            return app.initialize()
+                .then(function() {
+                    expect(fs.makeDirectory).to.be.calledWith('diff_dir');
+                });
+        });
+
+        it('should read tests', function() {
+            var app = mkApp_({
+                testFiles: ['test_file', 'another_test_file'],
+                grep: 'grep'
+            });
+
+            return app.initialize()
+                .then(function() {
+                    expect(Gemini.prototype.readTests)
+                        .to.be.calledWith(['test_file', 'another_test_file'], 'grep');
+                });
+        });
+    });
+
+    describe('run', function() {
+        it('should create and execute runner', function() {
+            var runnerInstance = sinon.createStubInstance(AllSuitesRunner);
+            sandbox.stub(RunnerFactory, 'create').returns(runnerInstance);
+
+            app.run();
+
+            expect(runnerInstance.run).to.be.called();
+        });
+
+        it('should pass run handler to runner which will execute gemeni', function() {
+            var runnerInstance = sinon.createStubInstance(AllSuitesRunner);
+
+            runnerInstance.run.yields();
+            sandbox.stub(RunnerFactory, 'create').returns(runnerInstance);
+
+            app.run();
+
+            expect(Gemini.prototype.test).to.be.called();
+        });
     });
 
     describe('addNoReferenceTest', function() {
@@ -54,6 +154,28 @@ describe('App', function() {
             app.addNoReferenceTest(test);
 
             expect(app.addFailedTest).to.be.calledWith(test);
+        });
+    });
+
+    describe('refPathToURL', function() {
+        beforeEach(function() {
+            app.referenceDirs = {
+                'browser_id': 'browser_reference_dir'
+            };
+        });
+
+        it('should append timestamp to resulting URL', function() {
+            var result = app.refPathToURL('full_path', 'browser_id');
+
+            return expect(result).to.match(/\?t=\d+/);
+        });
+    });
+
+    describe('currentPathToURL', function() {
+        it('should append timestamp to resulting URL', function() {
+            var result = app.currentPathToURL('full_path');
+
+            return expect(result).to.match(/\?t=\d+/);
         });
     });
 });

--- a/test/event-source.test.js
+++ b/test/event-source.test.js
@@ -1,7 +1,5 @@
 'use strict';
-var sinon = require('sinon'),
-    expect = require('chai').expect,
-    EventSource = require('../lib/event-source');
+var EventSource = require('../lib/event-source');
 
 describe('EventSource', function() {
     beforeEach(function() {

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -1,8 +1,6 @@
 'use strict';
 var EventEmitter = require('events').EventEmitter,
     q = require('q'),
-    sinon = require('sinon'),
-    expect = require('chai').expect,
     App = require('../lib/app'),
     reporter = require('../lib/reporter');
 

--- a/test/runner/all-suites-runner.test.js
+++ b/test/runner/all-suites-runner.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var _ = require('lodash'),
+    AllSuitesRunner = require('../../lib/runner/all-suites-runner'),
+
+    mkDummyCollection = require('../utils').mkDummyCollection;
+
+describe('AllSuitesRunner', function() {
+    var sandbox = sinon.sandbox.create();
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe('run', function() {
+        function run_(params) {
+            params = _.defaults(params || {}, {
+                collection: params.collection || mkDummyCollection(),
+                runHandler: params.runHandler || sandbox.stub().named('default_run_handler')
+            });
+
+            return new AllSuitesRunner(params.collection)
+                .run(params.runHandler);
+        }
+
+        it('should enable all suites in collection', function() {
+            var collection = mkDummyCollection();
+
+            run_({collection: collection});
+
+            expect(collection.enableAll).to.be.called();
+        });
+
+        it('should execute run handler', function() {
+            var collection = mkDummyCollection(),
+                runHandler = sandbox.stub().named('run_handler');
+
+            run_({
+                runHandler: runHandler,
+                collection: collection
+            });
+
+            expect(runHandler).to.be.calledWith(collection);
+        });
+
+        it('should return result of run handler', function() {
+            var runHandler = sandbox.stub().named('run_handler').returns('some_result'),
+                result = run_({runHandler: runHandler});
+
+            expect(result).to.be.equal('some_result');
+        });
+    });
+});

--- a/test/runner/index.js
+++ b/test/runner/index.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var RunnerFactory = require('../../lib/runner'),
+    AllSuitesRunner = require('../../lib/runner/all-suites-runner'),
+    SpecificSuitesRunner = require('../../lib/runner/specific-suites-runner'),
+
+    mkDummyCollection = require('../utils').mkDummyCollection;
+
+describe('RunnerFactory', function() {
+    var sandbox = sinon.sandbox.create();
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe('create', function() {
+        it('should create AllSuitesRunner if no specific tests passed', function() {
+            expect(RunnerFactory.create()).to.be.instanceOf(AllSuitesRunner);
+        });
+
+        it('should pass collection to AllSuitesRunner', function() {
+            var collection = mkDummyCollection(),
+                runner = RunnerFactory.create(collection),
+                runHandler = sandbox.stub();
+
+            runner.run(runHandler);
+
+            expect(runHandler).to.be.calledWith(collection);
+        });
+
+        it('should create SpecificSuitesRunner if specific tests passed', function() {
+            expect(RunnerFactory.create(null, ['test'])).to.be.instanceOf(SpecificSuitesRunner);
+        });
+
+        it('should pass suite collection and tests to SpecificSuiteRunner', function() {
+            var collection = mkDummyCollection(),
+                tests = [{
+                    suite: {path: 'suite'},
+                    state: {name: 'state'},
+                    browserId: 'browser'
+                }],
+                runner = RunnerFactory.create(collection, tests),
+                runHandler = sandbox.stub();
+
+            runner.run(runHandler);
+
+            expect(runHandler).to.be.calledWith(collection);
+            expect(collection.enable).to.be.calledOnce
+                .and.to.be.calledWith('suite', {state: 'state', browser: 'browser'});
+        });
+    });
+});

--- a/test/runner/specific-suites-runner.spec.js
+++ b/test/runner/specific-suites-runner.spec.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var _ = require('lodash'),
+    SpecificSuiteRunner = require('../../lib/runner/specific-suites-runner'),
+
+    mkDummyCollection = require('../utils').mkDummyCollection;
+
+describe('SpecificSuiteRunner', function() {
+    var sandbox = sinon.sandbox.create();
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe('run', function() {
+        function run_(params) {
+            params = _.defaults(params || {}, {
+                collection: mkDummyCollection(),
+                runHandler: params.runHandler || sandbox.stub().named('default_run_handler'),
+                tests: [{
+                    suite: {path: 'default_suite'},
+                    state: {name: 'default_state'},
+                    browserId: 'default_browser_id'
+                }]
+            });
+
+            return new SpecificSuiteRunner(params.collection, params.tests)
+                .run(params.runHandler);
+        }
+
+        it('should disable all suites in collection', function() {
+            var collection = mkDummyCollection();
+
+            run_({collection: collection});
+
+            expect(collection.disableAll).to.be.called();
+        });
+
+        it('should enable specific suites', function() {
+            var collection = mkDummyCollection(),
+                tests = [{
+                        suite: {path: 'suite'},
+                        state: {name: 'state'},
+                        browserId: 'browser'
+                    }];
+
+            run_({
+                collection: collection,
+                tests: tests
+            });
+
+            expect(collection.enable).to.be.calledOnce
+                .and.to.be.calledWith('suite', {state: 'state', browser: 'browser'});
+        });
+
+        it('should execute run handler', function() {
+            var collection = mkDummyCollection(),
+                runHandler = sandbox.stub().named('run_handler');
+
+            run_({
+                runHandler: runHandler,
+                collection: collection
+            });
+
+            expect(runHandler).to.be.calledWith(collection);
+        });
+
+        it('should return result of run handler', function() {
+            var runHandler = sandbox.stub().named('run_handler').returns('some_result'),
+                result = run_({runHandler: runHandler});
+
+            expect(result).to.be.equal('some_result');
+        });
+    });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,3 +4,7 @@ var chai = require('chai');
 
 chai.use(require('sinon-chai'));
 chai.use(require('chai-as-promised'));
+chai.use(require('dirty-chai'));
+
+global.expect = chai.expect;
+global.sinon = require('sinon');

--- a/test/tests-index.test.js
+++ b/test/tests-index.test.js
@@ -1,6 +1,5 @@
 'use strict';
 var TestsIndex = require('../lib/common/tests-index'),
-    expect = require('chai').expect,
     data = {
         onlySuite: {
             suite: {path: 'path/to/test'}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var format = require('util').format;
+
+function mkDummyCollection_() {
+    var collection = sinon.stub().named('SuiteCollection');
+
+    ['enable', 'enableAll', 'disable', 'disableAll'].forEach(function(method) {
+        collection[method] = sinon.stub().named(format('SuiteCollection.%s()', method));
+    });
+    collection.topLevelSuites = sinon.stub()
+        .named('SuiteCollection.topLevelSuites()')
+        .returns([]);
+
+    return collection;
+}
+
+exports.mkDummyCollection = mkDummyCollection_;


### PR DESCRIPTION
UI: 
* Добавлена кнопка запуска упавших тестов
* Для каждого упавшего теста появилась отдельная кнопка перезапуска
* Добавлен контроллер приложения. В него ушла реакция на события gemini, реакция на нажатия кнопок, список секций. Контроллер предоставляет API, которым можно пользоваться 
Под капотом:
* Добавлена явная инициализация - создание дерева директорий для отснятых картинок и диффов, чтение тестов
* Добавлено 2 раннера - для запуска всех сьютов и выборочного запуска.
* Исправлен старый баг со ссылками на картинки: эталоны кешировались на клиенте, при замене и повторном запуске сьютов показывался бракованный эталон.
* Добавлены тесты на новую функциональность.
* Из-за необходимости использовать `dirty-chai` пришлось обновить зависимости для тестирования.
