### PR TITLE
Don't rewrite stacktrace on states

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -117,7 +117,7 @@ App.prototype.addFailedTest = function(test) {
 
 App.prototype.updateReferenceImage = function(testData) {
     var _this = this,
-        test = this._failedTests.find(testData)[0];
+        test = this._failedTests.find(testData);
 
     if (!test) {
         return q.reject(new Error('No such test failed'));

--- a/lib/app.js
+++ b/lib/app.js
@@ -9,7 +9,7 @@ var path = require('path'),
     reporter = require('./reporter'),
 
     Tests = require('./tests-model'),
-    Index = require('./common/tests-index.js'),
+    Index = require('./common/tests-index'),
     EventSource = require('./event-source'),
     Runner = require('./runner');
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -9,7 +9,7 @@ var path = require('path'),
     reporter = require('./reporter'),
 
     Tests = require('./tests-model'),
-    Index = require('./common/tests-index'),
+    Index = require('./common/tests-index.js'),
     EventSource = require('./event-source'),
     Runner = require('./runner');
 
@@ -117,7 +117,7 @@ App.prototype.addFailedTest = function(test) {
 
 App.prototype.updateReferenceImage = function(testData) {
     var _this = this,
-        test = this._failedTests.find(testData);
+        test = this._failedTests.find(testData)[0];
 
     if (!test) {
         return q.reject(new Error('No such test failed'));

--- a/lib/client/controller.js
+++ b/lib/client/controller.js
@@ -33,6 +33,8 @@ Controller.prototype = {
         if (failed.length) {
             this._run(this._sections.findFailedStates());
         }
+
+        this._sections.resetErrors();
     },
 
     _run: function(failed) {
@@ -48,6 +50,8 @@ Controller.prototype = {
             }
             return failed? _this._sections.markAsQueued(failed) : _this._sections.markAllAsQueued();
         });
+
+        this._sections.resetErrors();
     },
 
     _toggleButtons: function(isEnabled) {

--- a/lib/client/controller.js
+++ b/lib/client/controller.js
@@ -150,7 +150,11 @@ Controller.prototype = {
                 });
 
             sections.forEach(function(section) {
-                console.error(data);
+                console.error(data, section);
+                // Если стейт только один (например, plain), то записать в него, а не в конце сьюита
+                if (Object.keys(sections.states).length === 1) {
+                    section = sections.states[Object.keys(sections.states)[0]].browsers[data.browserId];
+                }
                 section.setAsError({stack: data.stack, browserId: data.browserId, stateName: data.state && data.state.name});
                 section.expand();
                 _this._sections.markBranchAsFailed(section);

--- a/lib/client/controller.js
+++ b/lib/client/controller.js
@@ -33,6 +33,8 @@ Controller.prototype = {
         if (failed.length) {
             this._run(this._sections.findFailedStates());
         }
+
+        this._sections.resetErrors();
     },
 
     _run: function(failed) {
@@ -78,102 +80,121 @@ Controller.prototype = {
 
         eventSource.addEventListener('beginSuite', function(e) {
             var data = JSON.parse(e.data),
-                section = _this._sections.findSection({suite: data.suite});
+                sections = _this._sections.findSection({suite: data.suite});
 
-            if (section && section.status === 'queued') {
-                section.status = 'running';
-            }
+            sections.forEach(function(section) {
+                if (section && section.status === 'queued') {
+                    section.status = 'running';
+                }
+            });
         });
 
         eventSource.addEventListener('beginState', function(e) {
             var data = JSON.parse(e.data),
-                section = _this._sections.findSection({
+                sections = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state
                 });
 
-            if (section && section.status === 'queued') {
-                section.status = 'running';
-            }
+            sections.forEach(function(section) {
+                if (section && section.status === 'queued') {
+                    section.status = 'running';
+                }
+            });
         });
 
         eventSource.addEventListener('endTest', function(e) {
             var data = JSON.parse(e.data),
-                section = _this._sections.findSection({
+                sections = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state,
                     browserId: data.browserId
                 });
 
-            if (data.equal) {
-                section.setAsSuccess(data);
-            } else {
-                section.setAsFailure(data);
-                section.expand();
-                _this._sections.markBranchAsFailed(section);
-            }
+            sections.forEach(function(section) {
+                if (data.equal) {
+                    section.setAsSuccess(data);
+                } else {
+                    section.setAsFailure(data);
+                    section.expand();
+                    _this._sections.markBranchAsFailed(section);
+                }
+            });
         });
 
         eventSource.addEventListener('skipState', function(e) {
             var data = JSON.parse(e.data),
-                section = _this._sections.findSection({
-                    suite: data.suite,
-                    state: data.state,
-                    browserId: data.browserId
-                });
-            section.setAsSkipped();
-            var stateSection = _this._sections.findSection({
-                suite: data.suite,
-                state: data.state
-            });
-
-            _this._sections.markIfFinished(stateSection);
-        });
-
-        eventSource.addEventListener('err', function(e) {
-            var data = JSON.parse(e.data),
-                section = _this._sections.findSection({
-                    suite: data.suite,
-                    state: data.state,
-                    browserId: data.browserId
-                });
-            section.setAsError({stack: data.stack});
-            section.expand();
-            _this._sections.markBranchAsFailed(section);
-        });
-
-        eventSource.addEventListener('noReference', function(e) {
-            var data = JSON.parse(e.data),
-                section = _this._sections.findSection({
+                sections = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state,
                     browserId: data.browserId
                 });
 
-            section.setAsNewReference(data);
-            section.expand();
-            _this._sections.markBranchAsFailed(section);
-        });
-
-        eventSource.addEventListener('endState', function(e) {
-            var data = JSON.parse(e.data),
-                section = _this._sections.findSection({
+            sections.forEach(function(section) {
+                section.setAsSkipped();
+                var stateSections = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state
                 });
 
-            _this._sections.markIfFinished(section);
+                _this._sections.markIfFinished(stateSections);
+            });
         });
 
-        eventSource.addEventListener('endSuite', function(e) {
+        eventSource.addEventListener('err', function(e) {
             var data = JSON.parse(e.data),
-                section = _this._sections.findSection({
+                sections = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state,
                     browserId: data.browserId
                 });
 
-            _this._sections.markIfFinished(section);
+            sections.forEach(function(section) {
+                console.error(data);
+                section.setAsError({stack: data.stack, browserId: data.browserId, stateName: data.state && data.state.name});
+                section.expand();
+                _this._sections.markBranchAsFailed(section);
+            });
+        });
+
+        eventSource.addEventListener('noReference', function(e) {
+            var data = JSON.parse(e.data),
+                sections = _this._sections.findSection({
+                    suite: data.suite,
+                    state: data.state,
+                    browserId: data.browserId
+                });
+
+            sections.forEach(function(section) {
+                section.setAsNewReference(data);
+                section.expand();
+                _this._sections.markBranchAsFailed(section);
+            });
+        });
+
+        eventSource.addEventListener('endState', function(e) {
+            var data = JSON.parse(e.data),
+                sections = _this._sections.findSection({
+                    suite: data.suite,
+                    state: data.state
+                });
+
+            sections.forEach(function(section) {
+                _this._sections.markIfFinished(section);
+            });
+        });
+
+        eventSource.addEventListener('endSuite', function(e) {
+            var data = JSON.parse(e.data),
+                sections = _this._sections.findSection({
+                    suite: data.suite,
+                    state: data.state,
+                    browserId: data.browserId
+                });
+
+            sections.forEach(function(section) {
+                _this._sections.markIfFinished(section);
+            });
         });
 
         eventSource.addEventListener('end', function(e) {

--- a/lib/client/controller.js
+++ b/lib/client/controller.js
@@ -140,7 +140,7 @@ Controller.prototype = {
                 states = _this._sections.getSectionStates(data.suite && data.suite.path),
                 statesNames = Object.keys(states);
 
-            console.error(data, section); // jshint ignore:line
+            console.error('Test error', data, section); // jshint ignore:line
 
             // Если стейт только один (например, plain), то записать в него, а не в конце сьюита
             if (statesNames.length === 1) {

--- a/lib/client/controller.js
+++ b/lib/client/controller.js
@@ -50,6 +50,8 @@ Controller.prototype = {
             }
             return failed? _this._sections.markAsQueued(failed) : _this._sections.markAllAsQueued();
         });
+
+        this._sections.resetErrors();
     },
 
     _toggleButtons: function(isEnabled) {

--- a/lib/client/controller.js
+++ b/lib/client/controller.js
@@ -152,7 +152,7 @@ Controller.prototype = {
                 });
 
             sections.forEach(function(section) {
-                console.error(data, section);
+                console.error(data, section); // jshint ignore:line
                 // Если стейт только один (например, plain), то записать в него, а не в конце сьюита
                 if (Object.keys(sections.states).length === 1) {
                     section = sections.states[Object.keys(sections.states)[0]].browsers[data.browserId];

--- a/lib/client/controller.js
+++ b/lib/client/controller.js
@@ -33,8 +33,6 @@ Controller.prototype = {
         if (failed.length) {
             this._run(this._sections.findFailedStates());
         }
-
-        this._sections.resetErrors();
     },
 
     _run: function(failed) {
@@ -50,8 +48,6 @@ Controller.prototype = {
             }
             return failed? _this._sections.markAsQueued(failed) : _this._sections.markAllAsQueued();
         });
-
-        this._sections.resetErrors();
     },
 
     _toggleButtons: function(isEnabled) {
@@ -82,125 +78,116 @@ Controller.prototype = {
 
         eventSource.addEventListener('beginSuite', function(e) {
             var data = JSON.parse(e.data),
-                sections = _this._sections.findSection({suite: data.suite});
+                section = _this._sections.findSection({suite: data.suite});
 
-            sections.forEach(function(section) {
-                if (section && section.status === 'queued') {
-                    section.status = 'running';
-                }
-            });
+            if (section && section.status === 'queued') {
+                section.status = 'running';
+            }
         });
 
         eventSource.addEventListener('beginState', function(e) {
             var data = JSON.parse(e.data),
-                sections = _this._sections.findSection({
+                section = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state
                 });
 
-            sections.forEach(function(section) {
-                if (section && section.status === 'queued') {
-                    section.status = 'running';
-                }
-            });
+            if (section && section.status === 'queued') {
+                section.status = 'running';
+            }
         });
 
         eventSource.addEventListener('endTest', function(e) {
             var data = JSON.parse(e.data),
-                sections = _this._sections.findSection({
+                section = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state,
                     browserId: data.browserId
                 });
 
-            sections.forEach(function(section) {
-                if (data.equal) {
-                    section.setAsSuccess(data);
-                } else {
-                    section.setAsFailure(data);
-                    section.expand();
-                    _this._sections.markBranchAsFailed(section);
-                }
-            });
+            if (data.equal) {
+                section.setAsSuccess(data);
+            } else {
+                section.setAsFailure(data);
+                section.expand();
+                _this._sections.markBranchAsFailed(section);
+            }
         });
 
         eventSource.addEventListener('skipState', function(e) {
             var data = JSON.parse(e.data),
-                sections = _this._sections.findSection({
+                section = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state,
                     browserId: data.browserId
                 });
-
-            sections.forEach(function(section) {
-                section.setAsSkipped();
-                var stateSections = _this._sections.findSection({
-                    suite: data.suite,
-                    state: data.state
-                });
-
-                _this._sections.markIfFinished(stateSections);
+            section.setAsSkipped();
+            var stateSection = _this._sections.findSection({
+                suite: data.suite,
+                state: data.state
             });
+
+            _this._sections.markIfFinished(stateSection);
         });
 
         eventSource.addEventListener('err', function(e) {
             var data = JSON.parse(e.data),
-                sections = _this._sections.findSection({
+                section = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state,
                     browserId: data.browserId
-                });
+                }),
+                states = _this._sections.getSectionStates(data.suite && data.suite.path),
+                statesNames = Object.keys(states);
 
-            sections.forEach(function(section) {
-                console.error(data, section); // jshint ignore:line
-                // Если стейт только один (например, plain), то записать в него, а не в конце сьюита
-                if (Object.keys(sections.states).length === 1) {
-                    section = sections.states[Object.keys(sections.states)[0]].browsers[data.browserId];
-                }
-                section.setAsError({stack: data.stack, browserId: data.browserId, stateName: data.state && data.state.name});
-                section.expand();
-                _this._sections.markBranchAsFailed(section);
+            console.error(data, section); // jshint ignore:line
+
+            // Если стейт только один (например, plain), то записать в него, а не в конце сьюита
+            if (statesNames.length === 1) {
+                section = states[statesNames[0]].browsers[data.browserId];
+            }
+
+            section.setAsError({
+                stack: data.stack,
+                browserId: data.browserId,
+                stateName: data.state && data.state.name
             });
+            section.expand();
+            _this._sections.markBranchAsFailed(section);
         });
 
         eventSource.addEventListener('noReference', function(e) {
             var data = JSON.parse(e.data),
-                sections = _this._sections.findSection({
+                section = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state,
                     browserId: data.browserId
                 });
 
-            sections.forEach(function(section) {
-                section.setAsNewReference(data);
-                section.expand();
-                _this._sections.markBranchAsFailed(section);
-            });
+            section.setAsNewReference(data);
+            section.expand();
+            _this._sections.markBranchAsFailed(section);
         });
 
         eventSource.addEventListener('endState', function(e) {
             var data = JSON.parse(e.data),
-                sections = _this._sections.findSection({
+                section = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state
                 });
 
-            sections.forEach(function(section) {
-                _this._sections.markIfFinished(section);
-            });
+            _this._sections.markIfFinished(section);
         });
 
         eventSource.addEventListener('endSuite', function(e) {
             var data = JSON.parse(e.data),
-                sections = _this._sections.findSection({
+                section = _this._sections.findSection({
                     suite: data.suite,
                     state: data.state,
                     browserId: data.browserId
                 });
 
-            sections.forEach(function(section) {
-                _this._sections.markIfFinished(section);
-            });
+            _this._sections.markIfFinished(section);
         });
 
         eventSource.addEventListener('end', function(e) {

--- a/lib/client/section-list.js
+++ b/lib/client/section-list.js
@@ -59,19 +59,25 @@ SectionList.prototype = {
         });
     },
 
-    markIfFinished: function(section) {
-        if (section.status === 'fail') {
-            //already marked as fail
-            return;
+    markIfFinished: function(sections) {
+        if (!Array.isArray(sections)) {
+            sections = [sections];
         }
-        var nodes = section.domNode.querySelectorAll('.section');
-        var allChildrenFinished = every.call(nodes, function(node) {
-            return this._sectionForNode(node).isFinished();
-        }, this);
 
-        if (allChildrenFinished) {
-            section.status = 'success';
-        }
+        sections.forEach(function(section) {
+            if (section.status === 'fail') {
+                //already marked as fail
+                return;
+            }
+            var nodes = section.domNode.querySelectorAll('.section');
+            var allChildrenFinished = every.call(nodes, function(node) {
+                return this._sectionForNode(node).isFinished();
+            }, this);
+
+            if (allChildrenFinished) {
+                section.status = 'success';
+            }
+        }.bind(this));
     },
 
     markBranchAsFailed: function(fromSection) {
@@ -79,6 +85,12 @@ SectionList.prototype = {
             fromSection.status = 'fail';
             fromSection.expand();
         }
+    },
+
+    resetErrors: function() {
+        Array.from(document.querySelectorAll('.error')).forEach(function(e) {
+            e.innerHTML = '';
+        });
     },
 
     findSection: function(query) {
@@ -90,11 +102,11 @@ SectionList.prototype = {
             return this.findSection({
                 suite: section.suite,
                 state: section.state
-            });
+            })[0];
         }
 
         if (section.state && section.state.name) {
-            return this.findSection({suite: section.suite});
+            return this.findSection({suite: section.suite})[0];
         }
         var parentSectionNode = this._findParentSectionNode(section.domNode);
         if (parentSectionNode) {
@@ -139,7 +151,7 @@ SectionList.prototype = {
             browserId: domNode.getAttribute('data-browser-id')
         };
 
-        return this.findSection(query);
+        return this.findSection(query)[0];
     },
 
     _onRunState: function(state) {

--- a/lib/client/section-list.js
+++ b/lib/client/section-list.js
@@ -59,25 +59,19 @@ SectionList.prototype = {
         });
     },
 
-    markIfFinished: function(sections) {
-        if (!Array.isArray(sections)) {
-            sections = [sections];
+    markIfFinished: function(section) {
+        if (section.status === 'fail') {
+            //already marked as fail
+            return;
         }
+        var nodes = section.domNode.querySelectorAll('.section');
+        var allChildrenFinished = every.call(nodes, function(node) {
+            return this._sectionForNode(node).isFinished();
+        }, this);
 
-        sections.forEach(function(section) {
-            if (section.status === 'fail') {
-                //already marked as fail
-                return;
-            }
-            var nodes = section.domNode.querySelectorAll('.section');
-            var allChildrenFinished = every.call(nodes, function(node) {
-                return this._sectionForNode(node).isFinished();
-            }, this);
-
-            if (allChildrenFinished) {
-                section.status = 'success';
-            }
-        }.bind(this));
+        if (allChildrenFinished) {
+            section.status = 'success';
+        }
     },
 
     markBranchAsFailed: function(fromSection) {
@@ -87,14 +81,12 @@ SectionList.prototype = {
         }
     },
 
-    resetErrors: function() {
-        Array.from(document.querySelectorAll('.error')).forEach(function(e) {
-            e.innerHTML = '';
-        });
-    },
-
     findSection: function(query) {
         return this._sectionsIndex.find(query);
+    },
+
+    getSectionStates: function(suitePath) {
+        return this._sectionsIndex.getSectionStates(suitePath);
     },
 
     findParent: function(section) {
@@ -102,11 +94,11 @@ SectionList.prototype = {
             return this.findSection({
                 suite: section.suite,
                 state: section.state
-            })[0];
+            });
         }
 
         if (section.state && section.state.name) {
-            return this.findSection({suite: section.suite})[0];
+            return this.findSection({suite: section.suite});
         }
         var parentSectionNode = this._findParentSectionNode(section.domNode);
         if (parentSectionNode) {
@@ -151,11 +143,17 @@ SectionList.prototype = {
             browserId: domNode.getAttribute('data-browser-id')
         };
 
-        return this.findSection(query)[0];
+        return this.findSection(query);
     },
 
     _onRunState: function(state) {
         this._controller.runState(state);
+    },
+
+    resetErrors: function() {
+        Array.from(document.querySelectorAll('.error')).forEach(function(e) {
+            e.innerHTML = '';
+        });
     }
 };
 

--- a/lib/client/section.js
+++ b/lib/client/section.js
@@ -120,8 +120,20 @@ Section.prototype = {
     },
 
     setAsError: function(error) {
+        var buildSelector = function(error) {
+                return 'error-' + error.stateName + '-' + error.browserId;
+            },
+            errorContainer = this._bodyNode.querySelector('.' + buildSelector(error));
+
         this.status = 'fail';
-        this._bodyNode.innerHTML = errorTemplate(error);
+
+        if (!errorContainer) {
+            errorContainer = document.createElement('div');
+            errorContainer.className = 'error ' + buildSelector(error);
+            this._bodyNode.appendChild(errorContainer);
+        }
+
+        errorContainer.innerHTML += errorTemplate(error);
     },
 
     setAsNewReference: function(result) {

--- a/lib/common/tests-index.js
+++ b/lib/common/tests-index.js
@@ -57,7 +57,7 @@ TestsIndex.prototype = {
         var indexData = query.suite && this._index[query.suite.path],
             findStateIn = this._findStateIn.bind(this, query);
 
-        var items = indexData ? [findStateIn(indexData)] : _(this._index).map(findStateIn).flatten().value();
+        var items = indexData? [findStateIn(indexData)] : _(this._index).map(findStateIn).flatten().value();
         items.states = indexData.states;
         return items;
     },
@@ -71,7 +71,7 @@ TestsIndex.prototype = {
             findBrowserIn = this._findBrowserIn.bind(this, query.browserId);
 
         // Конкретный state не задан, значит считаем, что матчатся все стейты
-        return stateData ? findBrowserIn(stateData) : indexData.states.map(findBrowserIn);
+        return stateData? findBrowserIn(stateData) : indexData.states.map(findBrowserIn);
     },
 
     _findBrowserIn: function(browserId, stateData) {

--- a/lib/common/tests-index.js
+++ b/lib/common/tests-index.js
@@ -44,30 +44,42 @@ TestsIndex.prototype = {
 
     find: function(query) {
         if (Array.isArray(query)) {
-            return _(query)
-                .map(this.find, this)
-                .compact()
-                .value();
+            if (query.length > 1) {
+                return _(query)
+                    .map(this.find, this)
+                    .compact()
+                    .value();
+            } else {
+                query = query[0];
+            }
         }
 
-        var indexData = query.suite && this._index[query.suite.path];
-        if (!indexData) {
-            return null;
-        }
+        var indexData = query.suite && this._index[query.suite.path],
+            findStateIn = this._findStateIn.bind(this, query);
+
+        return indexData ? [findStateIn(indexData)] : _(this._index).map(findStateIn).flatten().value();
+    },
+
+    _findStateIn: function(query, indexData) {
         if (!query.state || query.state.name == null) {
             return indexData.suite;
         }
-        var stateData = indexData.states[query.state.name];
-        if (!stateData) {
-            return null;
-        }
 
-        if (query.browserId == null) {
+        var stateData = indexData.states[query.state.name],
+            findBrowserIn = this._findBrowserIn.bind(this, query.browserId);
+
+        // Конкретный state не задан, значит считаем, что матчатся все стейты
+        return stateData ? findBrowserIn(stateData) : indexData.states.map(findBrowserIn);
+    },
+
+    _findBrowserIn: function(browserId, stateData) {
+        if (browserId == null) {
             return stateData.state;
         }
 
-        return stateData.browsers[query.browserId] || null;
+        return stateData.browsers[browserId] || null;
     }
+
 };
 
 module.exports = TestsIndex;

--- a/lib/common/tests-index.js
+++ b/lib/common/tests-index.js
@@ -57,7 +57,9 @@ TestsIndex.prototype = {
         var indexData = query.suite && this._index[query.suite.path],
             findStateIn = this._findStateIn.bind(this, query);
 
-        return indexData ? [findStateIn(indexData)] : _(this._index).map(findStateIn).flatten().value();
+        var items = indexData ? [findStateIn(indexData)] : _(this._index).map(findStateIn).flatten().value();
+        items.states = indexData.states;
+        return items;
     },
 
     _findStateIn: function(query, indexData) {

--- a/lib/common/tests-index.js
+++ b/lib/common/tests-index.js
@@ -44,44 +44,35 @@ TestsIndex.prototype = {
 
     find: function(query) {
         if (Array.isArray(query)) {
-            if (query.length > 1) {
-                return _(query)
-                    .map(this.find, this)
-                    .compact()
-                    .value();
-            } else {
-                query = query[0];
-            }
+            return _(query)
+                .map(this.find, this)
+                .compact()
+                .value();
         }
 
-        var indexData = query.suite && this._index[query.suite.path],
-            findStateIn = this._findStateIn.bind(this, query);
-
-        var items = indexData? [findStateIn(indexData)] : _(this._index).map(findStateIn).flatten().value();
-        items.states = indexData.states;
-        return items;
-    },
-
-    _findStateIn: function(query, indexData) {
+        var indexData = query.suite && this._index[query.suite.path];
+        if (!indexData) {
+            return null;
+        }
         if (!query.state || query.state.name == null) {
             return indexData.suite;
         }
+        var stateData = indexData.states[query.state.name];
+        if (!stateData) {
+            return null;
+        }
 
-        var stateData = indexData.states[query.state.name],
-            findBrowserIn = this._findBrowserIn.bind(this, query.browserId);
-
-        // Конкретный state не задан, значит считаем, что матчатся все стейты
-        return stateData? findBrowserIn(stateData) : indexData.states.map(findBrowserIn);
-    },
-
-    _findBrowserIn: function(browserId, stateData) {
-        if (browserId == null) {
+        if (query.browserId == null) {
             return stateData.state;
         }
 
-        return stateData.browsers[browserId] || null;
-    }
+        return stateData.browsers[query.browserId] || null;
+    },
 
+    getSectionStates: function(suitePath) {
+        var indexData = this._index[suitePath];
+        return indexData.states;
+    }
 };
 
 module.exports = TestsIndex;

--- a/lib/static/main.css
+++ b/lib/static/main.css
@@ -151,6 +151,11 @@ html, body {
     font: 12px Consolas, Monaco, monospace;
 }
 
+.stacktrace__browser {
+    color: red;
+    font-weight: bold;
+}
+
 .controls__item {
     padding: 5px;
     display: inline-block;

--- a/lib/views/partials/error-result.hbs
+++ b/lib/views/partials/error-result.hbs
@@ -1,3 +1,4 @@
 <pre class="stacktrace">
+<span class="stacktrace__browser">{{#if stateName}}{{stateName}}{{else}}*{{/if}} — {{browserId}}</span>
 {{stack}}
 </pre>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build-client": "browserify lib/client --debug -p [minifyify --compressPath . --map /client.js.map.json --output ./lib/static/client.js.map.json] -t hbsfy -o ./lib/static/client.js",
+    "dev-build": "browserify lib/client --debug -t hbsfy -o ./lib/static/client.js",
     "prepublish": "npm run build-client",
     "test": "istanbul test _mocha --require ./test/setup.js test/*",
     "lint": "jshint . && jscs ."


### PR DESCRIPTION
Fix: if internal critical error caused at suite running before any state selected then stacktrace rewrites suite's body with all its states irreparably (until refresh gemini-gui page).

Now: write stacktraces into separated .error containers in suites.

ru:
> при ошибке во время выполнения сьюта убиваются все стейты

> Если произошла критическая ошибка до начала выполнения стейтов (например не отдался браузер), то информация об ошибке попадёт прямо под сьют, удаляя секции со стейтами. Даже если в других браузерах что-либо отработает или уже отработало, все удаляется. 
Ожидаемое поведение: писать ошибку во все стейты этого сьюта, фильтруя по браузеру, в котором произошла ошибка.

|      |     |
| --- | --- |
| <img width="100%" src="https://cloud.githubusercontent.com/assets/6201068/15269464/2137b5d0-1a10-11e6-905b-d90e1645ff6d.png">|<img width="100%" src="https://cloud.githubusercontent.com/assets/6201068/15269494/506a759e-1a11-11e6-88de-7dc6eb4e8a76.png">|
|![2016-05-14_19-30-35](https://cloud.githubusercontent.com/assets/6201068/15276940/38c08dd8-1b07-11e6-9192-772620911f75.png)|![2016-05-14_21-56-51](https://cloud.githubusercontent.com/assets/6201068/15270188/54d26cd4-1a27-11e6-9487-cd5284f33f0d.png)|