### PR TITLE
Wrap path.resolve into function to fix losing argument

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -13,7 +13,7 @@ exports.run = function() {
         .option('-b, --browser <browser>', 'run test only in the specified browser', collect)
         .option('-p, --port <port>', 'Port to launch server on', 8000)
         .option('-h, --hostname <hostname>', 'Hostname to launch server on', 'localhost')
-        .option('-c, --config <file>', 'Gemini config file', path.resolve)
+        .option('-c, --config <file>', 'Gemini config file', resolvePath)
         .option('-g, --grep <pattern>', 'run only suites matching the pattern', RegExp)
         .option('-a, --auto-run', 'auto run immediately')
         .parse(process.argv);
@@ -32,4 +32,8 @@ exports.run = function() {
 
 function collect(newValue, array) {
     return (array || []).concat(newValue);
+}
+
+function resolvePath(pathToResolve) {
+    return path.resolve(pathToResolve);
 }


### PR DESCRIPTION
Передача опции --config вызывает ошибку.
Не вполне понятно, почему, `path.resolve`, судя по исходникам, не завязана на this.
```bash
$ ./node_modules/.bin/gemini-gui --config .gemini-bs.yml test modules/**/__tests__/**/*-gemini.js
```
```bash
path.js:8
    throw new TypeError('Path must be a string. Received ' +
    ^

TypeError: Path must be a string. Received undefined
    at assertPath (path.js:8:11)
    at posix.resolve (path.js:426:5)
    at Command.<anonymous> (/Users/nitive/Work/cian-manager/frontend/node_modules/gemini-gui/node_modules/commander/index.js:395:35)
    at emitOne (events.js:77:13)
    at Command.emit (events.js:169:7)
    at Command.parseOptions (/Users/nitive/Work/cian-manager/frontend/node_modules/gemini-gui/node_modules/commander/index.js:690:14)
    at Command.parse (/Users/nitive/Work/cian-manager/frontend/node_modules/gemini-gui/node_modules/commander/index.js:455:21)
    at Object.exports.run (/Users/nitive/Work/cian-manager/frontend/node_modules/gemini-gui/lib/cli.js:19:10)
    at Object.<anonymous> (/Users/nitive/Work/cian-manager/frontend/node_modules/gemini-gui/bin/gemini-gui:3:23)
    at Module._compile (module.js:409:26)
```
---
node v4.4.2
npm v2.15.0