### PR TITLE
fix status on tests in html reporter

### DIFF
--- a/lib/common/tests-index.js
+++ b/lib/common/tests-index.js
@@ -35,7 +35,7 @@ TestsIndex.prototype = {
             };
         }
 
-        if (item.browserId === null) {
+        if (!item.browserId) {
             stateData.state = item;
             return;
         }
@@ -62,7 +62,7 @@ TestsIndex.prototype = {
             return null;
         }
 
-        if (query.browserId === null) {
+        if (!query.browserId) {
             return stateData.state;
         }
 


### PR DESCRIPTION
__Проблема в следующем:__
При прогоне тестов выполненными помечаются только браузеры в стейтах. Сами же стейты и сюйты висят в состоянии pending.

После того как начал откатываться назад по коммитам, нашел в чем же проблема. При внедрении eslint в gemini-gui он мне активно подсказывал, что нужно исправить.
Вот мы с ним вдвоем и исправили =)

Код до того, как мы с ~~моим корешом~~ eslint-ом поработали:
```js
if (item.browserId == null) { ... }
```

Код после:
```js
if (item.browserId === null) { ... }
```

Вроде бы мы все правильно сделали. Но оказывается, что browserId в определенных случаях равен `undefined`, а в других `null`. А как все знают `null == undefined` и они не равны ничему другому.

__А теперь подробнее про эти случаи:__
* `browserId === undefined`:
    - для самого сьюта
    - для стейтов
* `browserId === null`:
    - после завершения тестов для стейтов и сьютов. Так как в этом случае `browserId` считывается из атрибута указанного в текущей dom ноде. Данный атрибут указан только для тестов (по браузерам) внутри стейтов.

При использовании исправленного кода:
```js
if (!item.browserId) { ... }
```
логика не меняется и обрабатываются случаи как с `null` так и с `undefined`.