### PR TITLE
remove unnecessary output

### DIFF
--- a/lib/find-gemini.js
+++ b/lib/find-gemini.js
@@ -15,7 +15,7 @@ module.exports = function findGemini() {
             moduleDirectory: [
                 path.resolve(__dirname, '../../'),
                 'node_modules',
-                shell.exec('npm root --global').stdout.trim()
+                shell.exec('npm root --global', {silent: true}).stdout.trim()
             ]
         });
     } catch (e) {


### PR DESCRIPTION
It will drop this console.logs
```
npm WARN invalid config registry=undefined
npm WARN invalid config Must be a full url with 'http://'
/Users/sbmaxx/.nvm/versions/node/v4.5.0/lib/node_modules
```