### PR TITLE
Remove unused dependency handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "express": "^4.8.6",
     "express-handlebars": "^2.0.0",
     "fs-extra": "^0.30.0",
-    "handlebars": "^1.3.0",
     "inherit": "^2.2.3",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^3.10.1",


### PR DESCRIPTION
It was there from the beginning, but seems it was never used as express-handlebars comes with their own handlebar dependency