### PR TITLE
fix: remove shortcut for "hostname" cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Web browser with `GUI` loaded will be opened automatically.
 
 * `--config`, `-c` - specify config file to use.
 * `--port`, `-p` - specify port to run `GUI` backend on.
-* `--hostname`, `-h` - specify hostname to run `GUI` backend on.
+* `--hostname` - specify hostname to run `GUI` backend on.
 * `--root-url`, `-r` - use specified URL, instead of `rootUrl` setting from config file.
 * `--grid-url` - use specified URL, instead of `gridUrl` setting from config file.
 * `--screenshots-dir`, `-s` - use specified directory, instead of `screenshotsDir` setting

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,7 +16,7 @@ exports.run = () => {
         .allowUnknownOption(true)
         .option('-b, --browser <browser>', 'run test only in the specified browser', collect)
         .option('-p, --port <port>', 'Port to launch server on', 8000)
-        .option('-h, --hostname <hostname>', 'Hostname to launch server on', 'localhost')
+        .option('--hostname <hostname>', 'Hostname to launch server on', 'localhost')
         .option('-c, --config <file>', 'Gemini config file', path.resolve, '')
         .option('-g, --grep <pattern>', 'run only suites matching the pattern', RegExp)
         .option('-s, --set <set>', 'set to run', collect)


### PR DESCRIPTION
"-h" is traditionally used as a shortcut for "--help"