### PR TITLE
feat: add button to scale images and display horizontally

### DIFF
--- a/lib/client/controller.js
+++ b/lib/client/controller.js
@@ -71,6 +71,10 @@ Controller.prototype = {
             e.target.classList.toggle('button_checked');
             document.body.classList.toggle('report_showOnlyErrors');
         });
+        byId('toggleImageScale').addEventListener('click', function(e) {
+            e.target.classList.toggle('button_checked');
+            document.body.classList.toggle('images_scaled');
+        });
 
         this._runButton.addEventListener('click', function() {
             _this.run();

--- a/lib/static/main.css
+++ b/lib/static/main.css
@@ -77,6 +77,10 @@ html, body {
     border: 1px solid #ccc;
     border-radius: 2px;
 }
+.image-box {
+    display: flex;
+    flex-flow: row wrap;
+}
 
 .image-box, .error-box{
     background: #c9c9c9;
@@ -87,8 +91,16 @@ html, body {
 
 .image-box__image {
     padding:  0 5px;
-    display: inline-block;
+    display: block;
     vertical-align: top;
+    flex-basis: 33.333%;
+    box-sizing: border-box;
+    flex-grow: 1;
+}
+
+.images_scaled .image-box__image img {
+    max-width: 100%;
+    height: auto;
 }
 
 .image-box__replace {
@@ -205,6 +217,7 @@ html, body {
     background: #C9C9C9;
     position: -webkit-sticky;
     position: sticky;
+    width: 100%;
     top: 0;
 }
 

--- a/lib/views/main.hbs
+++ b/lib/views/main.hbs
@@ -23,6 +23,7 @@
             <button id="collapseAll" class="button">Collapse all</button>
             <button id="expandErrors" class="button">Expand errors</button>
             <button id="showOnlyErrors" class="button">Show only errors</button>
+            <button id="toggleImageScale" class="button">Scale images</button>
             <input id="viewHostInput" type="text" class="text-input" size="40" placeholder="change original host for view in browser"/>
             {{#each suites}}
                 {{> suite}}


### PR DESCRIPTION
If the images are too wide, the images will stack vertically, or may wrap with two on top and one below.

This PR forces the images to show in a row of three, and will scale down the images with CSS.