### PR TITLE
fix: do not fail on copying image

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -218,7 +218,8 @@ module.exports = class App {
 
     copyImage(srcRelPath, dstPath) {
         const srcPath = path.resolve(this._reusePath, srcRelPath);
-        return fs.copyAsync(srcPath, dstPath);
+        // it is ok that image can be defunct
+        return fs.copyAsync(srcPath, dstPath).catch(() => {});
     }
 
     static get refPrefix() {

--- a/lib/tests-model.js
+++ b/lib/tests-model.js
@@ -116,10 +116,15 @@ Tests.prototype = {
             const referencePath = this._app.getScreenshotPath(suite, state.name, browserId);
             const status = getStatus(state.shouldSkip(browserId), reuse);
 
-            // if status is 'success' then actualPath is present, but there is no image
-            const currentPath = reuse && reuse.result.actualPath && status !== 'success'
-                && this._app.createCurrentPathFor();
-            const diffPath = reuse && reuse.result.diffPath && this._app.createDiffPathFor();
+            const reuseResult = reuse && reuse.result;
+            let currentPath;
+            let diffPath;
+
+            if (reuseResult) {
+                // if status is 'success' then actualPath is present, but there is no image
+                currentPath = reuseResult.actualPath && status !== 'success' && this._app.createCurrentPathFor();
+                diffPath = reuseResult.diffPath && this._app.createDiffPathFor();
+            }
 
             const copyImagePromises = [
                 currentPath ? this._app.copyImage(reuse.result.actualPath, currentPath) : Promise.resolve(),

--- a/test/app.js
+++ b/test/app.js
@@ -267,14 +267,14 @@ describe('lib/app', () => {
             sandbox.stub(path, 'resolve');
         });
 
-        it('should reject if copying failed', () => {
-            fs.copyAsync.returns(Promise.reject());
-
+        it('should resolve if image was copied successfully', () => {
             return app.initialize()
-                .then(() => assert.isRejected(app.copyImage('src/rel/path', '/dst/abs/path')));
+                .then(() => assert.isFulfilled(app.copyImage('src/rel/path', '/dst/abs/path')));
         });
 
-        it('should resolve if image was copied successfully', () => {
+        it('should still resolve if copying failed', () => {
+            fs.copyAsync.returns(Promise.reject());
+
             return app.initialize()
                 .then(() => assert.isFulfilled(app.copyImage('src/rel/path', '/dst/abs/path')));
         });


### PR DESCRIPTION
User may want to reuse report with tests failed not only because of
diffs, but because of other errors, which may or may not have led to an absence of
images.